### PR TITLE
Support rejectIfNoRule

### DIFF
--- a/SpringSecurityMockGrailsPlugin.groovy
+++ b/SpringSecurityMockGrailsPlugin.groovy
@@ -66,7 +66,10 @@ class SpringSecurityMockGrailsPlugin {
 		println 'Configuring Spring Security Mock ...'
 
 		// mock authentication entry point
-		authenticationEntryPoint(MockAuthenticationEntryPoint)
+    authenticationEntryPoint(MockAuthenticationEntryPoint) {
+      grailsApplication = ref('grailsApplication')
+    }
+
 
 		// setup user details service
 	   	if (conf.userLookup.enabled) {

--- a/SpringSecurityMockGrailsPlugin.groovy
+++ b/SpringSecurityMockGrailsPlugin.groovy
@@ -25,11 +25,11 @@ import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
 	 */
 class SpringSecurityMockGrailsPlugin {
     // the plugin version
-    def version = "1.0.1"
+    def version = "1.0.2-SNAPSHOT"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3.7 > *"
     // the other plugins this plugin depends on
-    def dependsOn = [springSecurityCore: '1.2.7.2 > *']
+    def dependsOn = [springSecurityCore: '1.2.7.3 > *']
     
     // Make sure this loads AFTER the Spring Security LDAP plugin.
     def loadAfter = ['springSecurityLdap']

--- a/SpringSecurityMockGrailsPlugin.groovy
+++ b/SpringSecurityMockGrailsPlugin.groovy
@@ -66,9 +66,9 @@ class SpringSecurityMockGrailsPlugin {
 		println 'Configuring Spring Security Mock ...'
 
 		// mock authentication entry point
-    authenticationEntryPoint(MockAuthenticationEntryPoint) {
-      grailsApplication = ref('grailsApplication')
-    }
+		authenticationEntryPoint(MockAuthenticationEntryPoint) {
+			grailsApplication = ref('grailsApplication')
+		}
 
 
 		// setup user details service

--- a/application.properties
+++ b/application.properties
@@ -1,9 +1,10 @@
 #Grails Metadata file
-#Fri Jan 27 13:17:10 CST 2012
+#Fri Nov 23 06:25:49 CST 2012
 app.grails.version=2.0.0
 app.name=spring-security-mock
 plugins.code-coverage=1.2.5
 plugins.codenarc=0.16.1
 plugins.gmetrics=0.3.1
 plugins.hibernate=2.0.0
+plugins.release=2.0.4
 plugins.tomcat=2.0.0

--- a/application.properties
+++ b/application.properties
@@ -6,7 +6,4 @@ plugins.code-coverage=1.2.5
 plugins.codenarc=0.16.1
 plugins.gmetrics=0.3.1
 plugins.hibernate=2.0.0
-plugins.release=1.0.1
-plugins.spring-security-core=1.2.7.2
-plugins.spring-security-ldap=1.0.5
 plugins.tomcat=2.0.0

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -29,7 +29,9 @@ grails.project.dependency.resolution = {
         // runtime 'mysql:mysql-connector-java:5.1.13'
     }
 	plugins {
-		// compile		':spring-security-core:1.2.7.2'
+        compile ":spring-security-core:1.2.7.3"
+        compile ":spring-security-ldap:1.0.6"
+        build ":release:2.0.4"
 	}
 }
 

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -31,7 +31,6 @@ grails.project.dependency.resolution = {
 	plugins {
         compile ":spring-security-core:1.2.7.3"
         compile ":spring-security-ldap:1.0.6"
-        build ":release:2.0.4"
 	}
 }
 

--- a/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
+++ b/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletResponse
 import org.apache.log4j.Logger
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.security.core.AuthenticationException
+import org.springframework.security.authentication.InsufficientAuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
 	/* 
 	 * Grails Spring Security Mock Plugin - Fake Authentication for Spring Security

--- a/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
+++ b/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
@@ -42,17 +42,17 @@ class MockAuthenticationEntryPoint implements AuthenticationEntryPoint, Initiali
 
         // Obey deny-by-default
         if (grailsApplication.config.grails.plugins.springsecurity.rejectIfNoRule && authenticationException instanceof InsufficientAuthenticationException) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authenticationException.getMessage());
+          response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authenticationException.getMessage());
         } else {
-      logger.debug('commencing from exception' + authenticationException.toString())
+          logger.debug('commencing from exception' + authenticationException.toString())
 
-      // get the context
-      def contextPath = request.getContextPath()
+          // get the context
+          def contextPath = request.getContextPath()
 
-      // This matches the MockAuthenticationFilter URL
-      final String redirectUrl = contextPath + "/j_spring_mock_security_check"
+          // This matches the MockAuthenticationFilter URL
+          final String redirectUrl = contextPath + "/j_spring_mock_security_check"
 
-      response.sendRedirect(redirectUrl)
-    }
-}
+          response.sendRedirect(redirectUrl)
+        }
+  }
 }

--- a/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
+++ b/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
@@ -40,14 +40,19 @@ class MockAuthenticationEntryPoint implements AuthenticationEntryPoint, Initiali
 	public final void commence(final HttpServletRequest request, final HttpServletResponse response,
 	            final AuthenticationException authenticationException) throws IOException, ServletException {
 
-		logger.debug('commencing from exception' + authenticationException.toString())
+        // Obey deny-by-default
+        if (grailsApplication.config.grails.plugins.springsecurity.rejectIfNoRule && authenticationException instanceof InsufficientAuthenticationException) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authenticationException.getMessage());
+        } else {
+      logger.debug('commencing from exception' + authenticationException.toString())
 
-		// get the context
-		def contextPath = request.getContextPath()
+      // get the context
+      def contextPath = request.getContextPath()
 
-		// This matches the MockAuthenticationFilter URL
-		final String redirectUrl = contextPath + "/j_spring_mock_security_check"
+      // This matches the MockAuthenticationFilter URL
+      final String redirectUrl = contextPath + "/j_spring_mock_security_check"
 
-		response.sendRedirect(redirectUrl)
-	}
+      response.sendRedirect(redirectUrl)
+    }
+}
 }

--- a/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
+++ b/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
@@ -36,6 +36,7 @@ class MockAuthenticationEntryPoint implements AuthenticationEntryPoint, Initiali
 	void afterPropertiesSet() { }
 
 	static final Logger logger = Logger.getLogger(this)
+  def grailsApplication
 
 	/** Commences the login re-direct */
 	public final void commence(final HttpServletRequest request, final HttpServletResponse response,


### PR DESCRIPTION
Hi! Thanks for creating this plugin, it worked really well on a project I've been working on.

This pull request will make it so that the mock's behavior changes from "if there is an auth exception, provide the mock user" to "if there is an auth exception and it's not because of a deny-by-default rule, provide the mock user". In this way, it can be enforced that some parts of the application are available anonymously and some require a user, and if you're mocking in development, you can log in as the mock user without needing downstream LDAP or whatever.

I also bumped dependency versions as some of the old stuff wasn't available or building correctly.
