### PR TITLE
You can't redirect after response.sendError

### DIFF
--- a/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
+++ b/src/groovy/edu/umn/auth/MockAuthenticationEntryPoint.groovy
@@ -47,9 +47,9 @@ class MockAuthenticationEntryPoint implements AuthenticationEntryPoint, Initiali
         // Obey deny-by-default
         if (rejectIfNoRule && authenticationException instanceof InsufficientAuthenticationException) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authenticationException.getMessage());
-        } else {
-            logger.debug('commencing from exception' + authenticationException.toString())
+            return
         }
+            logger.debug('commencing from exception' + authenticationException.toString())
 
 		// get the context
 		def contextPath = request.getContextPath()

--- a/test/unit/edu/umn/auth/MockAuthenticationEntryPointTests.groovy
+++ b/test/unit/edu/umn/auth/MockAuthenticationEntryPointTests.groovy
@@ -35,9 +35,7 @@ class MockAuthenticationEntryPointTests {
         responseMocker.demand.sendError(1) { HttpServletResponse hsr, msg ->
             assert hsr == HttpServletResponse.SC_UNAUTHORIZED
         }
-        responseMocker.demand.sendRedirect(1) { String s ->
-            assert s == "/j_spring_mock_security_check"
-        }
+        responseMocker.demand.sendRedirect(0) { String s -> }
 		def response = responseMocker.createMock()
 
 		def authenticationException = new InsufficientAuthenticationException('TEST')


### PR DESCRIPTION
Once sendError has been called the response is committed and no
further redirect is possible.
