### PR TITLE
upgrade to grails-spring-security-core plugin 2.0-RC2

### DIFF
--- a/SpringSecurityMockGrailsPlugin.groovy
+++ b/SpringSecurityMockGrailsPlugin.groovy
@@ -2,9 +2,9 @@ import edu.umn.auth.MockAuthenticationEntryPoint
 import edu.umn.auth.MockAuthenticationProvider
 import edu.umn.auth.MockAuthenticationFilter
 import edu.umn.auth.MockUserDetailsService
-import org.codehaus.groovy.grails.plugins.springsecurity.GormUserDetailsService
-import org.codehaus.groovy.grails.plugins.springsecurity.SecurityFilterPosition
-import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.SecurityFilterPosition
+import grails.plugin.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.userdetails.GormUserDetailsService
 
 	/* 
 	 * Grails Spring Security Mock Plugin - Fake Authentication for Spring Security
@@ -25,11 +25,11 @@ import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
 	 */
 class SpringSecurityMockGrailsPlugin {
     // the plugin version
-    def version = "1.0.2"
+    def version = "1.1.0"
     // the version or versions of Grails the plugin is designed for
-    def grailsVersion = "1.3.7 > *"
+    def grailsVersion = "2.0.0 > *"
     // the other plugins this plugin depends on
-    def dependsOn = [springSecurityCore: '1.2.7.3 > *']
+    def dependsOn = [springSecurityCore: '2.0-RC2 > *']
     
     // Make sure this loads AFTER the Spring Security LDAP plugin.
     def loadAfter = ['springSecurityLdap']

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,5 @@
 #Grails Metadata file
-#Fri Jan 27 13:17:10 CST 2012
-app.grails.version=2.2.2
+#Thu Nov 21 16:29:55 CET 2013
+app.grails.version=2.3.1
 app.name=spring-security-mock
+app.servlet.version=2.5

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -10,30 +10,57 @@ grails.project.dependency.resolution = {
     log "warn" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
     repositories {
         grailsPlugins()
-        grailsHome()
         grailsCentral()
+        mavenLocal()
         mavenCentral()
+        mavenRepo 'http://repo.spring.io/milestone' // TODO remove
     }
     dependencies {
-        // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
+
+        String springSecurityVersion = '3.2.0.RC1'
+
+        compile "org.springframework.security:spring-security-core:$springSecurityVersion", {
+            excludes 'aopalliance', 'aspectjrt', 'cglib-nodep', 'commons-collections', 'commons-logging',
+                         'ehcache', 'fest-assert', 'hsqldb', 'jcl-over-slf4j', 'jsr250-api', 'junit',
+                         'logback-classic', 'mockito-core', 'powermock-api-mockito', 'powermock-api-support',
+                         'powermock-core', 'powermock-module-junit4', 'powermock-module-junit4-common',
+                         'powermock-reflect', 'spring-aop', 'spring-beans', 'spring-context', 'spring-core',
+                         'spring-expression', 'spring-jdbc', 'spring-test', 'spring-tx'
+                }
+
+        compile "org.springframework.security:spring-security-web:$springSecurityVersion", {
+            excludes 'aopalliance', 'commons-codec', 'commons-logging', 'fest-assert', 'groovy', 'hsqldb',
+                         'jcl-over-slf4j', 'junit', 'logback-classic', 'mockito-core', 'powermock-api-mockito',
+                         'powermock-api-support', 'powermock-core', 'powermock-module-junit4',
+                         'powermock-module-junit4-common', 'powermock-reflect', 'spock-core', 'spring-aop',
+                         'spring-beans', 'spring-context', 'spring-core', 'spring-expression', 'spring-jdbc',
+                         'spring-security-core', 'spring-test', 'spring-tx', 'spring-web', 'spring-webmvc',
+                         'tomcat-servlet-api'
+        }
     }
-	plugins {
+
+    plugins {
+
+        String hibernateVersion = '3.6.10.2'
+        String tomcatVersion = '7.0.42'
+        String securityPluginVersion = '2.0-RC2'
+
         // Grails Core Plugins
-        compile(":hibernate:${grailsVersion}") {
+        compile(":hibernate:${hibernateVersion}") {
             export = false
         }
-        runtime(":tomcat:${grailsVersion}") {
+        runtime(":tomcat:${tomcatVersion}") {
             export = false 
         }
 
         // Spring Security
-        compile ':spring-security-core:1.2.7.3'
-        compile(':spring-security-ldap:1.0.6') {
+        compile ":spring-security-core:${securityPluginVersion}"
+        compile(":spring-security-ldap:${securityPluginVersion}") {
             export = false
         }
 
         // Plugin Release
-        build(':release:2.1.0') {
+        build(':release:2.2.1') {
             export = false
         }
 

--- a/src/groovy/edu/umn/auth/MockUserDetailsService.groovy
+++ b/src/groovy/edu/umn/auth/MockUserDetailsService.groovy
@@ -1,7 +1,7 @@
 package edu.umn.auth
 
 import org.apache.log4j.Logger
-import org.codehaus.groovy.grails.plugins.springsecurity.GrailsUserDetailsService
+import grails.plugin.springsecurity.userdetails.GrailsUserDetailsService
 import org.springframework.dao.DataAccessException
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.Authentication


### PR DESCRIPTION
Some trivial package and dependency version changes to make the plugin compile and work with a more recent version of the core plugin.
