### PR TITLE
Upgrade to spring-security 2.0-RC2

### DIFF
--- a/SpringSecurityMockGrailsPlugin.groovy
+++ b/SpringSecurityMockGrailsPlugin.groovy
@@ -2,9 +2,9 @@ import edu.umn.auth.MockAuthenticationEntryPoint
 import edu.umn.auth.MockAuthenticationProvider
 import edu.umn.auth.MockAuthenticationFilter
 import edu.umn.auth.MockUserDetailsService
-import org.codehaus.groovy.grails.plugins.springsecurity.GormUserDetailsService
-import org.codehaus.groovy.grails.plugins.springsecurity.SecurityFilterPosition
-import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
+import grails.plugin.springsecurity.userdetails.GormUserDetailsService
+import grails.plugin.springsecurity.SecurityFilterPosition
+import grails.plugin.springsecurity.SpringSecurityUtils
 
 	/* 
 	 * Grails Spring Security Mock Plugin - Fake Authentication for Spring Security
@@ -25,11 +25,11 @@ import org.codehaus.groovy.grails.plugins.springsecurity.SpringSecurityUtils
 	 */
 class SpringSecurityMockGrailsPlugin {
     // the plugin version
-    def version = "1.0.3"
+    def version = "2.0-RC2"
     // the version or versions of Grails the plugin is designed for
-    def grailsVersion = "1.3.7 > *"
+    def grailsVersion = "2.3 > *"
     // the other plugins this plugin depends on
-    def dependsOn = [springSecurityCore: '1.2.7.3 > *']
+    def dependsOn = [springSecurityCore: '2.0-RC2 > *']
     
     // Make sure this loads AFTER the Spring Security LDAP plugin.
     def loadAfter = ['springSecurityLdap']

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,5 @@
 #Grails Metadata file
-#Fri Jan 27 13:17:10 CST 2012
-app.grails.version=2.2.3
+#Mon Nov 25 15:08:34 MST 2013
+app.grails.version=2.3.3
 app.name=spring-security-mock
+app.servlet.version=2.5

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -13,22 +13,23 @@ grails.project.dependency.resolution = {
         grailsHome()
         grailsCentral()
         mavenCentral()
+        mavenRepo 'http://repo.spring.io/milestone'
     }
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
     }
 	plugins {
         // Grails Core Plugins
-        compile(":hibernate:${grailsVersion}") {
+        compile(":hibernate:3.6.10.4") {
             export = false
         }
-        runtime(":tomcat:${grailsVersion}") {
+        runtime(":tomcat:7.0.47") {
             export = false 
         }
 
         // Spring Security
-        compile ':spring-security-core:1.2.7.3'
-        compile(':spring-security-ldap:1.0.6') {
+        compile ':spring-security-core:2.0-RC2'
+        compile(':spring-security-ldap:2.0-RC2') {
             export = false
         }
 

--- a/src/groovy/edu/umn/auth/MockUserDetailsService.groovy
+++ b/src/groovy/edu/umn/auth/MockUserDetailsService.groovy
@@ -1,7 +1,7 @@
 package edu.umn.auth
 
 import org.apache.log4j.Logger
-import org.codehaus.groovy.grails.plugins.springsecurity.GrailsUserDetailsService
+import grails.plugin.springsecurity.userdetails.GrailsUserDetailsService
 import org.springframework.dao.DataAccessException
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.Authentication


### PR DESCRIPTION
Burt has released spring-security-core 2.0-RC2 for Grails 2.3 compatibility. This commit updates spring-security-mock to work with the 2.0-RC2 versions.
